### PR TITLE
feat: make inventory responsive

### DIFF
--- a/src/pages/inventory/Inventory.css
+++ b/src/pages/inventory/Inventory.css
@@ -1,24 +1,30 @@
+/* Layout container */
 .inventory-container {
   width: 100%;
   height: 100%;
   display: flex;
   flex-direction: column;
   justify-content: center;
-  align-items: end;
+  align-items: flex-end;
   gap: 2rem;
+  padding: 1rem;
 }
 
+/* List of products */
 .inventory-list {
   width: 100%;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 1rem;
 }
 
+
+/* Individual product */
 .inventory-item {
   display: flex;
   padding: 1rem;
   border: 1px solid var(--color-tertiary);
+  background-color: var(--color-background, #fff);
 }
 .inventory-item-title {
   font-size: 1.2rem;
@@ -28,6 +34,7 @@
   font-weight: bold;
 }
 
+/* Product image */
 .inventory-item-image {
   width: 96px;
   object-fit: cover;
@@ -47,6 +54,30 @@
   display: flex;
   flex-direction: row;
   gap: 0.5rem;
+  margin-left: auto;
 }
 
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .inventory-container {
+    align-items: center;
+  }
+
+  .inventory-item {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+
+  .inventory-item-image {
+    margin-right: 0;
+    margin-bottom: 0.5rem;
+  }
+
+  .inventory-item-actions {
+    margin-left: 0;
+    margin-top: 0.5rem;
+    justify-content: center;
+  }
+}
 


### PR DESCRIPTION
## Summary
- make inventory grid responsive and stack items on small screens

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3c7b86f6c8329a4aa92759f63bc90